### PR TITLE
Downgrade sensor name fix

### DIFF
--- a/custom_components/rte_ecowatt/__init__.py
+++ b/custom_components/rte_ecowatt/__init__.py
@@ -166,7 +166,7 @@ class NextDowngradedEcowattLevel(CoordinatorEntity, RestorableCoordinatedSensor)
         self._restored = False
         self.hass = hass
         _LOGGER.info("Creating ecowatt sensor for next downgraded period")
-        self._name = "Next downgraded period"
+        self._attr_name = "Next downgraded period"
         self._state = None
         self._attr_extra_state_attributes: Dict[str, Any] = {}
 


### PR DESCRIPTION
Fix default name for rte downgrade sensor.
Was 'rte ecowatt ecowatt next downgraded period' used `self._attr_name ` instead of `self._name `