### PR TITLE
⬆ Define integration type

### DIFF
--- a/custom_components/rte_ecowatt/manifest.json
+++ b/custom_components/rte_ecowatt/manifest.json
@@ -7,6 +7,7 @@
   "domain": "rte_ecowatt",
   "documentation": "https://github.com/kamaradclimber/rte-ecowatt",
   "issue_tracker": "https://github.com/kamaradclimber/rte-ecowatt/issues",
+  "integration_type": "device",
   "codeowners": ["@kamaradclimber"],
   "name": "My EcoWatt by RTE",
   "config_flow": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "My EcoWatt by RTE",
   "render_readme": true,
-  "country": "fr"
+  "country": "fr",
+  "homeassistant": "2022.11"
 }


### PR DESCRIPTION
This integration does not even define a single "device" but there is no better option apparently

This requires latest version of homeassistant

Change-Id: I339c68d88d13b4903ed43cfc2da183b74892fabc