### PR TITLE
📓 Rename calendar

### DIFF
--- a/custom_components/rte_ecowatt/__init__.py
+++ b/custom_components/rte_ecowatt/__init__.py
@@ -238,7 +238,7 @@ class DowngradedEcowattLevelCalendar(CoordinatorEntity, CalendarEntity):
     def __init__(self, coordinator: EcoWattAPICoordinator, hass: HomeAssistant):
         CoordinatorEntity.__init__(self, coordinator)
         self.hass = hass
-        self._attr_name = "Ecowatt downgraded level calendar"
+        self._attr_name = "Ecowatt downgraded level"
         self._events = []
 
     @property


### PR DESCRIPTION
We don't need to name it calendar since it is already part of its identity

Fix #38 