### PR TITLE
🐛 Fix integration restoration with disabled entities

### DIFF
--- a/custom_components/rte_ecowatt/sensor.py
+++ b/custom_components/rte_ecowatt/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import EntityPlatformState
 from homeassistant.config_entries import ConfigEntry
 
 from . import (
@@ -76,8 +77,10 @@ async def async_setup_entry(
         sensors.append(DetectedAddress(enedis_coordinator, hass))
 
     async_add_entities(sensors)
-    while not all(s.restored for s in sensors):
-        _LOGGER.debug("Wait for all sensors to have been restored")
+    while not all(
+        s.restored for s in sensors if s._platform_state == EntityPlatformState.ADDED
+    ):
+        _LOGGER.debug(f"Wait for all {len(sensors)} sensors to have been restored")
         await asyncio.sleep(0.2)
     _LOGGER.debug("All sensors have been restored properly")
 


### PR DESCRIPTION
When disabling entities, restoration will not happen (because entities are not *added* to home assistant anymore).
This patch will simply ignore those entities (even though they are still defined)

This may have an impact for #28 (not sure since I can't reproduce any other conditions so far)

Change-Id: I51f8fba454d83920d370abb09272e63ae387e9e1