### PR TITLE
🐛 Reduce foreseeable future

### DIFF
--- a/custom_components/rte_ecowatt/config_flow.py
+++ b/custom_components/rte_ecowatt/config_flow.py
@@ -157,7 +157,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: Optional[dict[str, Any]] = None
     ):
         return self._manual_configuration_step(
-            "hours", vol.In(range(4 * 24)), user_input
+            "hours", vol.In(range(3 * 24)), user_input
         )
 
     async def async_step_configure_days_sensor(


### PR DESCRIPTION
Ecowatt API publishes data between 3 and 4 days in advance. It seems that only 3 days are guaranteed: they build prevision for the next 4 days each morning.

Fixes #30

Change-Id: I26013f62d8781b8116ac4260f10a47a82323ae68