### PR TITLE
🐛 Force search by street

### DIFF
--- a/custom_components/rte_ecowatt/__init__.py
+++ b/custom_components/rte_ecowatt/__init__.py
@@ -509,7 +509,7 @@ class EnedisAPICoordinator(DataUpdateCoordinator):
             lat = self.hass.config.as_dict()["latitude"]
             lon = self.hass.config.as_dict()["longitude"]
         r = await client.get(
-            f"https://api-adresse.data.gouv.fr/reverse/?lat={lat}&lon={lon}"
+            f"https://api-adresse.data.gouv.fr/reverse/?lat={lat}&lon={lon}&type=street"
         )
         if not r.is_success:
             raise UpdateFailed(


### PR DESCRIPTION
type query parameter is necessary to contrain type of data we are looking for. Issue #45 is gives an example where the returned item is a municipality instead of a street/housenumber.

Fixes #45

Change-Id: I18d77b4ef5536425ceef9eab08609185a6ba39f4