### PR TITLE
🐛 Adapt to 2023.6

### DIFF
--- a/custom_components/rte_ecowatt/__init__.py
+++ b/custom_components/rte_ecowatt/__init__.py
@@ -217,14 +217,16 @@ class RestorableCoordinatedSensor(RestoreSensor):
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
         _LOGGER.debug("starting to restore sensor from previous data")
-        if (last_stored_state := await self._async_get_restored_data()) is not None:
-            old_state = last_stored_state.state.as_dict()
-            _LOGGER.debug(f"old state: {old_state}")
-            if old_state["state"] != "unknown" or self.restore_even_if_unknown():
+
+        if (extra_stored_data := await self.async_get_last_sensor_data()) is not None:
+            if (
+                extra_stored_data.native_value != "unknown"
+                or self.restore_even_if_unknown()
+            ):
                 _LOGGER.debug(f"Restoring state for {self.unique_id}")
-                self._state = old_state["state"]
-                for key, value in old_state["attributes"].items():
-                    self._attr_extra_state_attributes[key] = value
+                self._attr_native_value = extra_stored_data.native_value
+                self._attr_native_unit_of_measurement = extra_stored_data.native_unit_of_measurement
+                # sadly it seems as of 2023.6 we don't have any way to get back the additional attributes
                 self.coordinator.last_update_success = True
             else:
                 # by not restoring state, we allow the Coordinator to fetch data again and fill


### PR DESCRIPTION
I should really learn not to use internal APIs :)

HA/core removes the async keyword on a method called "async" 🤦 leading to #61.

This patch fixes it at the expense of not restoring "extra" attributes (such as "generation time", "period start", "period end" and "level code") which is very sad.

Fix #61

Change-Id: I3aade86daaa46cf83eb49a0e90ccb83c3dbeba9f