### PR TITLE
⬆ Support v5 of the RTE API

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@ Use [hacs](https://hacs.xyz/).
 ### Get api access for RTE APIs
 
 - Create an account on [RTE API website](https://data.rte-france.com/web/guest)
-- Register to the [Ecowatt API](https://data.rte-france.com/catalog/-/api/consumption/Ecowatt/v4.0) and click on "Abonnez-vous à l'API", create a new application
+- Register to the [Ecowatt API](https://data.rte-france.com/catalog/-/api/consumption/Ecowatt/v5.0) and click on "Abonnez-vous à l'API", create a new application
 - get the `client_id` and `client_secret` (uuid in both cases)
 
 ### Configure home-assistant

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Utilisez [hacs](https://hacs.xyz/).
 ### Obtenir un accès API pour les API RTE
 
 - Créer un compte sur [site API RTE](https://data.rte-france.com/web/guest)
-- Inscrivez-vous à l'[API Ecowatt](https://data.rte-france.com/catalog/-/api/consumption/Ecowatt/v4.0) et cliquez sur "Abonnez-vous à l'API", créez un nouvelle application
+- Inscrivez-vous à l'[API Ecowatt](https://data.rte-france.com/catalog/-/api/consumption/Ecowatt/v5.0) et cliquez sur "Abonnez-vous à l'API", créez un nouvelle application
 - obtenir le `client_id` et `client_secret` (uuid dans les deux cas)
 
 ### Configurer home-assistant


### PR DESCRIPTION
We try v5 first and fallback to v4 if we receive a 403. There is apparently no way to know if an api key has been generated for v5 or v4 but they are incompatible. Only way to know is to test at runtime.

Fix #68
Fix #67