### PR TITLE
💥 Remove enedis load shedding sensors

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,8 +2,6 @@
 
 Component to expose Ecowatt levels for the foreseable future. See https://www.monecowatt.fr/ for web access.
 
-The integration optionaly exposes load shedding information via Enedis website. This feature is opt-in because it shares localization information via a 3rd party website. It is activated via /config/integrations page (click on "Configure" button next to the RTE Ecowatt card).
-
 ## Installation
 
 Use [hacs](https://hacs.xyz/).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Composant pour exposer les niveaux Ecowatt dans un avenir prévisible. Voir https://www.monecowatt.fr/ pour l'accès web.
 
-L'intégration expose également optionellement des informations sur les délestages locaux via le site d'Enedis.
-Cette fonctionnalité est désactivée par défaut car elle partage des information de localisation avec un site tiers. Elle peut-être configurée dans la page /config/integrations en cliquant sur "Configurer".
-
 ## Installation
 
 Utilisez [hacs](https://hacs.xyz/).

--- a/custom_components/rte_ecowatt/calendar.py
+++ b/custom_components/rte_ecowatt/calendar.py
@@ -10,13 +10,10 @@ from homeassistant.config_entries import ConfigEntry
 
 from . import (
     EcoWattAPICoordinator,
-    EnedisAPICoordinator,
     DowngradedEcowattLevelCalendar,
-    EnedisNextDowngradedPeriods,
 )
 from .const import (
     DOMAIN,
-    CONF_ENEDIS_LOAD_SHEDDING,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,13 +24,8 @@ async def async_setup_entry(
 ) -> None:
     _LOGGER.info("Called async setup entry for calendar")
     rte_coordinator = hass.data[DOMAIN][entry.entry_id]["rte_coordinator"]
-    enedis_coordinator = hass.data[DOMAIN][entry.entry_id]["enedis_coordinator"]
     sensors = []
     sensors.append(DowngradedEcowattLevelCalendar(rte_coordinator, hass))
-    if entry.data[CONF_ENEDIS_LOAD_SHEDDING][
-        0
-    ]:  # this sensor transmit PII to external provider, it's opt-in
-        sensors.append(EnedisNextDowngradedPeriods(enedis_coordinator, hass))
 
     async_add_entities(sensors)
 

--- a/custom_components/rte_ecowatt/config_flow.py
+++ b/custom_components/rte_ecowatt/config_flow.py
@@ -13,7 +13,6 @@ from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_SENSORS,
-    CONF_ENEDIS_LOAD_SHEDDING,
     CONF_SENSOR_UNIT,
     CONF_SENSOR_SHIFT,
 )
@@ -31,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(self, user_input: Optional[dict[str, Any]] = None):
         """Called once with None as user_input, then a second time with user provided input"""
@@ -58,8 +57,6 @@ class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.user_input = user_input
                 if "sensors" not in self.user_input:
                     self.user_input["sensors"] = []
-                if CONF_ENEDIS_LOAD_SHEDDING not in self.user_input:
-                    self.user_input[CONF_ENEDIS_LOAD_SHEDDING] = [False]
 
                 return self._configuration_menu("user")
 
@@ -124,26 +121,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "finish_configuration",
                 "configure_hours_sensor",
                 "configure_days_sensor",
-                "enable_load_shedding_announcements",
             ],
-        )
-
-    async def async_step_enable_load_shedding_announcements(
-        self, user_input: Optional[dict[str, Any]] = None
-    ):
-        step_name = f"enable_load_shedding_announcements"
-        errors = {}
-        data_schema = {vol.Required(CONF_ENEDIS_LOAD_SHEDDING): vol.Coerce(bool)}
-        if user_input is not None:
-            self.user_input[CONF_ENEDIS_LOAD_SHEDDING][0] = user_input[
-                CONF_ENEDIS_LOAD_SHEDDING
-            ]
-            return self._configuration_menu(step_name)
-
-        return self.async_show_form(
-            step_id=step_name,
-            data_schema=vol.Schema(data_schema),
-            errors=errors,
         )
 
     async def async_step_finish_configuration(

--- a/custom_components/rte_ecowatt/const.py
+++ b/custom_components/rte_ecowatt/const.py
@@ -1,7 +1,6 @@
 DOMAIN = "rte_ecowatt"
 CONF_CLIENT_ID = "api_client_id"
 CONF_CLIENT_SECRET = "api_client_secret"
-CONF_ENEDIS_LOAD_SHEDDING = "enedis_load_shedding"
 CONF_SENSORS = "sensors"
 CONF_SENSOR_UNIT = "unit"
 CONF_SENSOR_SHIFT = "shift"

--- a/custom_components/rte_ecowatt/sensor.py
+++ b/custom_components/rte_ecowatt/sensor.py
@@ -17,14 +17,11 @@ from homeassistant.config_entries import ConfigEntry
 from . import (
     HourlyEcowattLevel,
     DailyEcowattLevel,
-    ElectricityDistributorEntity,
-    DetectedAddress,
 )
 from .const import (
     DOMAIN,
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
-    CONF_ENEDIS_LOAD_SHEDDING,
     CONF_SENSOR_UNIT,
     CONF_SENSOR_SHIFT,
     CONF_SENSORS,
@@ -43,7 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_CLIENT_ID): cv.string,
         vol.Required(CONF_CLIENT_SECRET): cv.string,
-        vol.Required(CONF_ENEDIS_LOAD_SHEDDING): vol.All(cv.ensure_list, [cv.boolean]),
         vol.Required(CONF_SENSORS, default=[]): vol.All(
             cv.ensure_list, [SENSOR_SCHEMA]
         ),
@@ -56,7 +52,6 @@ async def async_setup_entry(
 ) -> None:
     _LOGGER.info("Called async setup entry")
     rte_coordinator = hass.data[DOMAIN][entry.entry_id]["rte_coordinator"]
-    enedis_coordinator = hass.data[DOMAIN][entry.entry_id]["enedis_coordinator"]
     sensors = []
     sensors.append(DailyEcowattLevel(rte_coordinator, 0, hass))
     sensors.append(HourlyEcowattLevel(rte_coordinator, 0, hass))
@@ -70,12 +65,6 @@ async def async_setup_entry(
             raise Exception("Unknown sensor unit type")
         sensors.append(klass(rte_coordinator, sensor_config[CONF_SENSOR_SHIFT], hass))
 
-    if entry.data[CONF_ENEDIS_LOAD_SHEDDING][
-        0
-    ]:  # this sensor transmit PII to external provider, it's opt-in
-        sensors.append(ElectricityDistributorEntity(enedis_coordinator, hass))
-        sensors.append(DetectedAddress(enedis_coordinator, hass))
-
     async_add_entities(sensors)
     while not all(
         s.restored for s in sensors if s._platform_state == EntityPlatformState.ADDED
@@ -86,11 +75,6 @@ async def async_setup_entry(
 
     # we declare update_interval after initialization to avoid a first refresh before we setup entities
     rte_coordinator.update_interval = timedelta(minutes=16)
-    enedis_coordinator.update_interval = timedelta(hours=1)
-    if entry.data[CONF_ENEDIS_LOAD_SHEDDING][0]:
-        # force a first refresh immediately to avoid waiting for 1 hour
-        await enedis_coordinator.async_config_entry_first_refresh()
-        enedis_coordinator._schedule_refresh()
     # force a first refresh immediately to avoid waiting for 16 minutes
     if any(
         s.state is None for s in sensors if s.coordinator == rte_coordinator

--- a/custom_components/rte_ecowatt/strings.json
+++ b/custom_components/rte_ecowatt/strings.json
@@ -23,20 +23,7 @@
         "menu_options": {
           "finish_configuration": "Finish configuration",
           "configure_hours_sensor": "Configure another sensor with hour granularity",
-          "configure_days_sensor": "Configure another sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
-        }
-      },
-      "enable_load_shedding_announcements": {
-        "description": "Expose information about planned load shedding",
-        "data": {
-          "enedis_load_shedding": "Fetch load shedding information from enedis. I understand my HA instance latitude/longitude will be sent to api-adresse.data.gouv.fr to detect my address."
-        },
-        "menu_options": {
-          "finish_configuration": "Finish configuration",
-          "configure_hours_sensor": "Configure sensor with hour granularity",
-          "configure_days_sensor": "Configure sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
+          "configure_days_sensor": "Configure another sensor with day granularity"
         }
       },
       "configure_hours_sensor": {
@@ -47,8 +34,7 @@
         "menu_options": {
           "finish_configuration": "Finish configuration",
           "configure_hours_sensor": "Configure another sensor with hour granularity",
-          "configure_days_sensor": "Configure another sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
+          "configure_days_sensor": "Configure another sensor with day granularity"
         }
       },
       "configure_days_sensor": {
@@ -59,8 +45,7 @@
         "menu_options": {
           "finish_configuration": "Finish configuration",
           "configure_hours_sensor": "Configure another sensor with hour granularity",
-          "configure_days_sensor": "Configure another sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
+          "configure_days_sensor": "Configure another sensor with day granularity"
         }
       }
     },

--- a/custom_components/rte_ecowatt/translations/en.json
+++ b/custom_components/rte_ecowatt/translations/en.json
@@ -23,20 +23,7 @@
         "menu_options": {
           "finish_configuration": "Finish configuration",
           "configure_hours_sensor": "Configure another sensor with hour granularity",
-          "configure_days_sensor": "Configure another sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
-        }
-      },
-      "enable_load_shedding_announcements": {
-        "description": "Expose information about planned load shedding",
-        "data": {
-          "enedis_load_shedding": "Fetch load shedding information from enedis. I understand my HA instance latitude/longitude will be sent to api-adresse.data.gouv.fr to detect my address."
-        },
-        "menu_options": {
-          "finish_configuration": "Finish configuration",
-          "configure_hours_sensor": "Configure sensor with hour granularity",
-          "configure_days_sensor": "Configure sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
+          "configure_days_sensor": "Configure another sensor with day granularity"
         }
       },
       "configure_hours_sensor": {
@@ -47,8 +34,7 @@
         "menu_options": {
           "finish_configuration": "Finish configuration",
           "configure_hours_sensor": "Configure another sensor with hour granularity",
-          "configure_days_sensor": "Configure another sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
+          "configure_days_sensor": "Configure another sensor with day granularity"
         }
       },
       "configure_days_sensor": {
@@ -59,8 +45,7 @@
         "menu_options": {
           "finish_configuration": "Finish configuration",
           "configure_hours_sensor": "Configure another sensor with hour granularity",
-          "configure_days_sensor": "Configure another sensor with day granularity",
-          "enable_load_shedding_announcements": "Look for load shedding announcements"
+          "configure_days_sensor": "Configure another sensor with day granularity"
         }
       }
     },

--- a/custom_components/rte_ecowatt/translations/fr.json
+++ b/custom_components/rte_ecowatt/translations/fr.json
@@ -23,20 +23,7 @@
         "menu_options": {
           "finish_configuration": "Terminer la configuration",
           "configure_hours_sensor": "Configurer un autre capteur avec une granularité horaire",
-          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière",
-          "enable_load_shedding_announcements": "Obtenir liste des délestages locaux via Enedis"
-        }
-      },
-      "enable_load_shedding_announcements": {
-        "description": "Récupération des délestages locaux via Enedis",
-        "data": {
-          "enedis_load_shedding": "Récupérer la liste des déléstages locaux via le site d'Enedis. Je comprends que les informations de locatisation (latitude/longitude) configurées dans HA seront envoyées à api-adresse.data.gouv.fr pour obtenir cette information."
-        },
-        "menu_options": {
-          "finish_configuration": "Terminer la configuration",
-          "configure_hours_sensor": "Configurer un autre capteur avec une granularité horaire",
-          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière",
-          "enable_load_shedding_announcements": "Obtenir liste des délestages locaux via Enedis"
+          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière"
         }
       },
       "configure_hours_sensor": {
@@ -47,8 +34,7 @@
         "menu_options": {
           "finish_configuration": "Terminer la configuration",
           "configure_hours_sensor": "Configurer un autre capteur avec une granularité horaire",
-          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière",
-          "enable_load_shedding_announcements": "Obtenir liste des délestages locaux via Enedis"
+          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière"
         }
       },
       "configure_days_sensor": {
@@ -59,8 +45,7 @@
         "menu_options": {
           "finish_configuration": "Terminer la configuration",
           "configure_hours_sensor": "Configurer un autre capteur avec une granularité horaire",
-          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière",
-          "enable_load_shedding_announcements": "Obtenir liste des délestages locaux via Enedis"
+          "configure_days_sensor": "Configurer un autre capteur avec une granularité journalière"
         }
       }
     },


### PR DESCRIPTION
These sensors have been broken for a long time because Enedis removed the API without warning a few months ago. They are unlikely to come back.

Fix #75
Fix #63